### PR TITLE
Relax version constraints

### DIFF
--- a/fernet.cabal
+++ b/fernet.cabal
@@ -29,13 +29,13 @@ library
                      , Network.Fernet.Crypto
                      , Network.Fernet.Key
                      , Network.Fernet.Token
-  build-depends:       base >=4.9 && <4.10
+  build-depends:       base >=4.9 && <4.18
                      , binary               >= 0.8.3.0 && < 0.10
                      , byteable             >= 0.1.1  && < 0.2
-                     , bytestring           >= 0.10.8 && < 0.11
-                     , cryptonite           >= 0.21   && < 0.23
-                     , memory               >= 0.14.1 && < 0.15
-                     , time                 >= 1.6.0  && < 1.7
+                     , bytestring           >= 0.10.8 && < 0.12
+                     , cryptonite           >= 0.21   && < 0.31
+                     , memory               >= 0.14.1 && < 0.18
+                     , time                 >= 1.6.0  && < 1.10
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings


### PR DESCRIPTION
Confirmed that it is buildable on GHC 9.2 after this change